### PR TITLE
Two fusions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 #Ignore csv files in the inputs folder
 simple/*.csv
 RFR/inputs_gcc/*.csv
-RFR/inputs_weather/*.csv
+RFR/inputs_weather/*/*.csv
 RFR/PEG_RFR/**/*.csv
 RFR/PEG_RFR0/**/*.csv
 RFR/PEG_RFR2/**/*.csv

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ RFR/PEG_RFR/**/*.csv
 RFR/PEG_RFR0/**/*.csv
 RFR/PEG_RFR2/**/*.csv
 RFR/PEG_FUSION_0/**/*.csv
+RFR/PEG_FUSION_1/**/*.csv

--- a/RFR/01_pull_gcc_weather.R
+++ b/RFR/01_pull_gcc_weather.R
@@ -1,3 +1,4 @@
+.libPaths(c("/home/kristinariemer/r_libs/", .libPaths()))
 ###########Pull input data###########
 
 # gcc from ecoforecast.org
@@ -15,7 +16,7 @@ library(readr)
 library(dplyr)
 library(udunits2)
 library(plantecophys)
-source("~/neon4cast/R/noaa.R")
+source("/home/kristinariemer/neon4cast/R/noaa.R")
 
 ###########Download weather data###########
 pheno_sites <- c("BART", "CLBJ", "DELA", "GRSM", 

--- a/RFR/01_pull_gcc_weather.R
+++ b/RFR/01_pull_gcc_weather.R
@@ -87,9 +87,11 @@ ens <- unique(daily_ens$ensemble)
 
 write_csv(daily, file = paste0('inputs_weather/median/NOAA_GEFS_35d_', date, '.csv'))
 
-for(e in ens){
-  sub <- filter(daily_ens, ensemble == e)
-  write_csv(sub, file = paste0('inputs_weather/ensemble/NOAA_GEFS_35d_', 
-                                 date, '_', e, '.csv'))
-}
+write_csv(daily_ens, file = paste0('inputs_weather/ensemble/NOAA_GEFS_35d_', date, '.csv'))
+
+# for(e in ens){
+#   sub <- filter(daily_ens, ensemble == e)
+#   write_csv(sub, file = paste0('inputs_weather/ensemble/NOAA_GEFS_35d_', 
+#                                  date, '_', e, '.csv'))
+# }
 

--- a/RFR/05_PEG_FUSION_0_future_predictions.py
+++ b/RFR/05_PEG_FUSION_0_future_predictions.py
@@ -8,7 +8,7 @@ import numpy as np
 # Getting current working directory
 dirname = os.path.abspath(os.getcwd())
 
-# Getting latest phenology from 'inputs_gss' folder
+# Getting latest phenology from 'inputs_gcc' folder
 inputs_path = os.path.join(dirname, 'inputs_gcc')
 file_type = '/*csv'
 files = glob.glob(inputs_path + file_type)

--- a/RFR/05_PEG_FUSION_1_future_predictions.py
+++ b/RFR/05_PEG_FUSION_1_future_predictions.py
@@ -8,7 +8,7 @@ import numpy as np
 # Getting current working directory
 dirname = os.path.abspath(os.getcwd())
 
-# Getting latest phenology from 'inputs_gss' folder
+# Getting latest phenology from 'inputs_gcc' folder
 inputs_path = os.path.join(dirname, 'inputs_gcc')
 file_type = '/*csv'
 files = glob.glob(inputs_path + file_type)

--- a/RFR/05_PEG_FUSION_1_future_predictions.py
+++ b/RFR/05_PEG_FUSION_1_future_predictions.py
@@ -16,7 +16,7 @@ latest_file = max(files, key=os.path.getctime)
 dataset = pd.read_csv(latest_file)
 
 # Getting latest forecasted weather parameters from 'inputs_weather' folder
-forecasted_weather_path = os.path.join(dirname, 'inputs_weather/median')
+forecasted_weather_path = os.path.join(dirname, 'inputs_weather/ensemble')
 file_type = '/*csv'
 forecasted_weather_files = glob.glob(forecasted_weather_path + file_type)
 latest_forecasted_weather_file = max(forecasted_weather_files, key=os.path.getctime)
@@ -153,6 +153,6 @@ for k in range(0,num_sites):
 
 
 # Generating output csv files with predictions
-outputs_path = os.path.join(dirname, 'PEG_FUSION_0', 'outputs/')
-output_file_name= "PEG_FUSION_0_predictions_" + str(date.today().strftime("%m-%d-%y"))+ ".csv"
+outputs_path = os.path.join(dirname, 'PEG_FUSION_1', 'outputs/')
+output_file_name= "PEG_FUSION_1_predictions_" + str(date.today().strftime("%m-%d-%y"))+ ".csv"
 future_predictions.to_csv(outputs_path + output_file_name, index=False, header = True)

--- a/RFR/06_submit_fusion.R
+++ b/RFR/06_submit_fusion.R
@@ -1,3 +1,4 @@
+.libPaths(c("/home/kristinariemer/r_libs/", .libPaths()))
 ### Submission script for the Fall 2021 EFI Challenge: Phenology
 # remotes::install_github("eco4cast/neon4cast")
 # library(neon4cast)
@@ -6,24 +7,49 @@ library(tidyr)
 library(dplyr)
 
 # loop to read, clean, score, validate, and submit prediction
-version <- c("PEG_FUSION_0")
+version <- c("PEG_FUSION_0", "PEG_FUSION_1")
+
+
 for(v in version){
+  if(!dir.exists(paste0(v, '/submissions'))) {
+    dir.create(paste0(v, '/submissions'))
+  }
+  
   # Read in latest date
   out <- list.files(path = paste0("./", v, "/outputs/"))
   dates <- as.Date(stringr::str_extract(out, "[0-9]{2}\\-[0-9]{2}\\-[0-9]{2}"), format = "%m-%d-%y")
   ind <- which.max(dates)
   
   # Clean and format
-  preds <- readr::read_csv(file.path(v, "outputs", out[ind])) %>%
-    filter(!time <= Sys.Date()) %>%
-    relocate(gcc_sd, rcc_sd, .after = rcc_90) %>%
-    pivot_longer(cols = c('gcc_90', 'rcc_90', 'gcc_sd', 'rcc_sd'),
-                 names_to = c("variable", "statistic"),
-                 names_pattern = "(.*)_(.*)",
-                 values_to = 'value') %>%
-    mutate(statistic = recode(statistic, `90` = "mean")) %>%
-    pivot_wider(names_from = variable, values_from = value) %>%
-    rename(gcc_90 = gcc, rcc_90 = rcc)
+  if(v == "PEG_FUSION_0"){
+    preds <- readr::read_csv(file.path(v, "outputs", out[ind])) %>%
+      filter(!time <= Sys.Date()) %>%
+      relocate(gcc_sd, rcc_sd, .after = rcc_90) %>%
+      pivot_longer(cols = c('gcc_90', 'rcc_90', 'gcc_sd', 'rcc_sd'),
+                   names_to = c("variable", "statistic"),
+                   names_pattern = "(.*)_(.*)",
+                   values_to = 'value') %>%
+      mutate(statistic = recode(statistic, `90` = "mean")) %>%
+      pivot_wider(names_from = variable, values_from = value) %>%
+      rename(gcc_90 = gcc, rcc_90 = rcc)
+  } else if(v == "PEG_FUSION_1"){
+    preds <- readr::read_csv(file.path(v, "outputs", out[ind])) %>%
+      filter(!time <= Sys.Date()) %>%
+      mutate(time = as.Date(time, format = "%m/%d/%Y")) %>%
+      select(-gcc_sd, -rcc_sd) %>%
+      group_by(time, siteID) %>%
+      summarize(gcc_mean = mean(gcc_90),
+                gcc_sd = sd(gcc_90),
+                rcc_mean = mean(rcc_90),
+                rcc_sd = sd(rcc_90)) %>%
+      pivot_longer(cols = c('gcc_mean', 'gcc_sd', 'rcc_mean', 'rcc_sd'),
+                   names_to = c("variable", "statistic"),
+                   names_pattern = "(.*)_(.*)",
+                   values_to = 'value') %>%
+      pivot_wider(names_from = variable, values_from = value) %>%
+      rename(gcc_90 = gcc, rcc_90 = rcc)
+  }
+  
   
   # Score
   # scores <- score(preds, theme = "phenology")

--- a/RFR/06_submit_fusion.R
+++ b/RFR/06_submit_fusion.R
@@ -65,7 +65,7 @@ for(v in version){
   Sys.setenv("AWS_DEFAULT_REGION" = "data",
              "AWS_S3_ENDPOINT" = "ecoforecast.org")
   
-  aws.s3::put_object(file.path(".", v, "submissions", pred_filename), 
+  aws.s3::put_object(file = file.path(".", v, "submissions", pred_filename), 
                      bucket = "submissions")
   
 }

--- a/RFR/06_submit_fusion.R
+++ b/RFR/06_submit_fusion.R
@@ -62,8 +62,10 @@ for(v in version){
   # forecast_output_validator(file.path(".", v, "submit", pred_filename))
   
   # Submit
-  aws.s3::put_object(file.path(".", v, "submissions", pred_filename), 
-                     bucket = "submissions", 
-                     region="data", 
-                     base_url = "ecoforecast.org")
+  Sys.setenv("AWS_DEFAULT_REGION" = "data",
+             "AWS_S3_ENDPOINT" = "ecoforecast.org")
+  
+  aws.s3::put_object(object = file.path(".", v, "submissions", pred_filename), 
+                     bucket = "submissions")
+  
 }

--- a/RFR/06_submit_fusion.R
+++ b/RFR/06_submit_fusion.R
@@ -65,7 +65,7 @@ for(v in version){
   Sys.setenv("AWS_DEFAULT_REGION" = "data",
              "AWS_S3_ENDPOINT" = "ecoforecast.org")
   
-  aws.s3::put_object(object = file.path(".", v, "submissions", pred_filename), 
+  aws.s3::put_object(file.path(".", v, "submissions", pred_filename), 
                      bucket = "submissions")
   
 }

--- a/RFR/forecast_gcc.sh
+++ b/RFR/forecast_gcc.sh
@@ -5,4 +5,5 @@ Rscript 01_pull_gcc_weather.R
 # python3 03_PEG_RFR_gcc_predictions_with_interpolation.py
 # python3 04_PEG_RFR2_gcc_predictions_with_weather_variables.py
 python3 05_PEG_FUSION_0_future_predictions.py
+python3 05_PEG_FUSION_1_future_predictions.py
 Rscript 06_submit_fusion.R


### PR DESCRIPTION
Modify to have 2 fusion scripts - one for median weather inputs, another for ensemble weather inputs. How gcc and rcc sd are calculated also differ substantially. 

The changes are primarily to 01_pull_gcc_weather.R and 06_submit_fusion.R. There are now two versions of the weather variables saved in `inputs_weather` under the folders `median` and `ensemble`. Note that the median weather takes the median across ensembles first, then summarizes to daily, whereas the ensemble groups by site, ensemble, and date to summarize to daily in one step. There is no need to separate the ensembles individually, the model accepts multiple site/time combinations and the output matches accordingly. The submission script is slightly modified to match [updated instructions from EFI](https://projects.ecoforecast.org/neon4cast-docs/submission-instructions.html#validating-submission), and there are two processing procedures. 